### PR TITLE
changing to lts node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: lts/*
 sudo: required
 dist: trusty
 install:


### PR DESCRIPTION
newest "stable" version of node is breaking our test build. changing to the LTS version